### PR TITLE
rough update to 1.20.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.parallel = true
 
 # Fabric properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version  = 1.20.4
-yarn_mappings      = 1.20.4+build.3
-loader_version     = 0.15.3
+minecraft_version  = 1.20.6
+yarn_mappings      = 1.20.6+build.3
+loader_version     = 0.15.11
 
 # Mod properties
-mod_version        = 1.1.2
+mod_version        = 1.2.0
 maven_group        = retr0.carrotconfig
 archives_base_name = carrotconfig
 
 # Dependencies
-fabric_version     = 0.92.0+1.20.4
+fabric_version     = 0.99.0+1.20.6
 # https://modrinth.com/mod/modmenu/versions#all-versions
-mod_menu_version   = 9.0.0
+mod_menu_version   = 10.0.0-beta.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/retr0/carrotconfig/config/CarrotConfigScreen.java
+++ b/src/main/java/retr0/carrotconfig/config/CarrotConfigScreen.java
@@ -10,6 +10,7 @@ import net.minecraft.text.OrderedText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
 import retr0.carrotconfig.CarrotConfigClient;
 import retr0.carrotconfig.entries.*;
 
@@ -28,7 +29,7 @@ public class CarrotConfigScreen extends Screen {
     public ConfigEntryList entryList;
     public List<CarrotConfig.EntryInfo> entries;
     private final Map<AbstractConfigEntry, Field> entryMap = new HashMap<>();
-
+    public static final Identifier OPTIONS_BACKGROUND_TEXTURE = new Identifier("textures/gui/options_background.png");
     protected CarrotConfigScreen(Screen parent, String modId, List<CarrotConfig.EntryInfo> entries) {
         super(Text.translatable(modId + ".carrotconfig.title").formatted(Formatting.BOLD, Formatting.GRAY));
 
@@ -98,7 +99,7 @@ public class CarrotConfigScreen extends Screen {
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        renderBackgroundTexture(context);
+        renderBackgroundTexture(context, OPTIONS_BACKGROUND_TEXTURE, 0, 0, 0.0F, 0.0F, this.width, this.height);
         super.render(context, mouseX, mouseY, delta);
 
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 10, 0xFFFFFF);

--- a/src/main/java/retr0/carrotconfig/entries/ConfigEntryList.java
+++ b/src/main/java/retr0/carrotconfig/entries/ConfigEntryList.java
@@ -52,7 +52,7 @@ public class ConfigEntryList extends ElementListWidget<AbstractConfigEntry> {
     }
 
 
-    @Override public int getScrollbarPositionX() { return width - 7; }
+    @Override public int getScrollbarX() { return width - 7; }
 
     @Override public int getRowWidth() { return 10000; }
 }


### PR DESCRIPTION
A rough update to 1.20.6 tested with Bedrock Waters (1.20.4). Should fix config GUI rendering by updating two overridden functions that were changed in Minecrafts base 1.20.6's EntryListWidget class. After this basic update, the mod could compile and build and Bedrock Water's config no longer crashes.

Most likely needs more testing

Note: Bedrock Waters seems to work with no update, however even so I have a fork with dependency updates as well as updating the resource pack getName() method to getId(). I cannot get this update to run on the client through IntelliJ, but it seems to work on a normal client if you want to take a look.