### PR TITLE
Updated codebase for Minecraft 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -56,8 +56,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    // Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-    it.options.release = 17
+    // Minecraft 1.21 (24w14a) upwards uses Java 21.
+    it.options.release = 21
 }
 
 java {
@@ -66,13 +66,13 @@ java {
     // If you remove this line, sources will not be generated.
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${archivesBaseName}"}
+        rename { "${it}_${base.archivesName}"}
     }
 }
 
@@ -80,6 +80,7 @@ jar {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            artifactId = 'carrotconfig'
             from components.java
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.parallel = true
 
 # Fabric properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version  = 1.20.4
-yarn_mappings      = 1.20.4+build.3
-loader_version     = 0.15.3
+minecraft_version  = 1.21
+yarn_mappings      = 1.21+build.9
+loader_version     = 0.15.11
 
 # Mod properties
-mod_version        = 1.1.2
-maven_group        = retr0.carrotconfig
+mod_version        = 1.1.3
+maven_group        = com.github.2Retr0
 archives_base_name = carrotconfig
 
 # Dependencies
-fabric_version     = 0.92.0+1.20.4
+fabric_version     = 0.100.6+1.21
 # https://modrinth.com/mod/modmenu/versions#all-versions
-mod_menu_version   = 9.0.0
+mod_menu_version   = 11.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/retr0/carrotconfig/config/CarrotConfigScreen.java
+++ b/src/main/java/retr0/carrotconfig/config/CarrotConfigScreen.java
@@ -98,7 +98,7 @@ public class CarrotConfigScreen extends Screen {
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        renderBackgroundTexture(context);
+        renderDarkening(context);
         super.render(context, mouseX, mouseY, delta);
 
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 10, 0xFFFFFF);

--- a/src/main/java/retr0/carrotconfig/entries/ConfigEntryList.java
+++ b/src/main/java/retr0/carrotconfig/entries/ConfigEntryList.java
@@ -52,7 +52,7 @@ public class ConfigEntryList extends ElementListWidget<AbstractConfigEntry> {
     }
 
 
-    @Override public int getScrollbarPositionX() { return width - 7; }
+    @Override public int getScrollbarX() { return width - 7; }
 
     @Override public int getRowWidth() { return 10000; }
 }


### PR DESCRIPTION
This updates the codebase to be compatible with version 1.21. All dependencies plus the Java and Gradle versions themselves had been bumped to the latest available. It also updates both the Maven group and artifact ID to properly use the `publishToMavenLocal` task.

@2Retr0 I could not find an already created branch for the 1.21 update, so feel free to update the base branch for the PR.